### PR TITLE
Fix background commands failing in legacy mode

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -2,9 +2,9 @@ name: FreeBSD
 
 on:
   push:
-    branches: [main]
+    branches: [main, '0.*']
   pull_request:
-    branches: [main]
+    branches: [main, '0.*']
 
 jobs:
   build:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,9 +2,9 @@ name: Linux
 
 on:
   push:
-    branches: [main]
+    branches: [main, '0.*']
   pull_request:
-    branches: [main]
+    branches: [main, '0.*']
 
 jobs:
   build:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,9 +2,9 @@ name: macOS
 
 on:
   push:
-    branches: [main]
+    branches: [main, '0.*']
   pull_request:
-    branches: [main]
+    branches: [main, '0.*']
 
 jobs:
   build:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,9 +2,9 @@ name: Windows
 
 on:
   push:
-    branches: [main]
+    branches: [main, '0.*']
   pull_request:
-    branches: [main]
+    branches: [main, '0.*']
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -28,14 +28,10 @@ bin/
 googletest-prefix/
 
 # Test binaries
-tests/test_config
-tests/test_pid_file
-tests/test_executor
-tests/test_data_dir
-tests/test_database
-tests/test_process
-tests/test_log_manager
-tests/test_daemonize
+tests/test_*
+!tests/test_*.cc
+!tests/test_*.ps1
+!tests/test_*.sh
 
 # GTest discovery artifacts
 tests/cmake_test_discovery_*.json

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ tests/test_data_dir
 tests/test_database
 tests/test_process
 tests/test_log_manager
+tests/test_daemonize
 
 # GTest discovery artifacts
 tests/cmake_test_discovery_*.json

--- a/src/daemonize.cc
+++ b/src/daemonize.cc
@@ -10,6 +10,7 @@ bool daemonize(){
 #else
 
 #include <unistd.h>
+#include <fcntl.h>
 
 bool daemonize(){
     pid_t pid = fork();
@@ -21,9 +22,20 @@ bool daemonize(){
     }
     setsid();
     chdir("/");
-    close(STDIN_FILENO);
-    close(STDOUT_FILENO);
-    close(STDERR_FILENO);
+
+    // Redirect stdin/stdout/stderr to /dev/null rather than closing them.
+    // Closing FDs 0-2 violates POSIX: child processes launched via system()
+    // inherit closed FDs, causing backgrounded commands (&) to silently fail.
+    // This matches the behavior of daemon(0, 0).
+    // See: https://github.com/homer6/frequent-cron/issues/17
+    int fd = open("/dev/null", O_RDWR);
+    if( fd != -1 ){
+        dup2(fd, STDIN_FILENO);
+        dup2(fd, STDOUT_FILENO);
+        dup2(fd, STDERR_FILENO);
+        if( fd > 2 ) close(fd);
+    }
+
     return true;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,12 @@ add_executable( test_log_manager test_log_manager.cc )
 target_link_libraries( test_log_manager ${CMAKE_PROJECT_NAME}_lib GTest::gtest_main )
 gtest_discover_tests( test_log_manager )
 
+if(NOT WIN32)
+    add_executable( test_daemonize test_daemonize.cc )
+    target_link_libraries( test_daemonize ${CMAKE_PROJECT_NAME}_lib GTest::gtest_main )
+    gtest_discover_tests( test_daemonize )
+endif()
+
 # Integration tests (shell-based)
 if(WIN32)
     add_test(NAME integration_tests

--- a/tests/test_daemonize.cc
+++ b/tests/test_daemonize.cc
@@ -1,0 +1,198 @@
+#include <gtest/gtest.h>
+
+#ifndef _WIN32
+
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <cstdlib>
+#include <cstdio>
+#include <string>
+#include <sys/wait.h>
+#include <filesystem>
+
+// Regression tests for https://github.com/homer6/frequent-cron/issues/17
+//
+// The bug: daemonize() closed FDs 0-2 instead of redirecting to /dev/null.
+// POSIX declares execution with closed standard FDs "non-conforming", causing
+// backgrounded commands (command &) to silently fail on some platforms.
+//
+// These tests verify the FD state after daemonization setup, which is the
+// deterministic root cause regardless of platform shell behavior.
+
+static std::string make_temp_path( const std::string& name ){
+    return std::filesystem::temp_directory_path() / ("fc_test_" + name + "_" + std::to_string(getpid()));
+}
+
+TEST(Daemonize, ClosedFDsAreInvalid) {
+    // Prove that closing FDs 0-2 leaves them invalid.
+    // This is the broken state that caused the regression.
+
+    pid_t pid = fork();
+    ASSERT_NE(pid, -1);
+
+    if( pid == 0 ){
+        close(STDIN_FILENO);
+        close(STDOUT_FILENO);
+        close(STDERR_FILENO);
+
+        // FDs 0-2 should be invalid after close
+        int r0 = fcntl(STDIN_FILENO, F_GETFD);
+        int r1 = fcntl(STDOUT_FILENO, F_GETFD);
+        int r2 = fcntl(STDERR_FILENO, F_GETFD);
+
+        // All three should return -1 (invalid)
+        _exit((r0 == -1 && r1 == -1 && r2 == -1) ? 0 : 1);
+    }
+
+    int status;
+    waitpid(pid, &status, 0);
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 0) << "Closed FDs should be invalid";
+}
+
+TEST(Daemonize, ClosedFDsCauseReuse) {
+    // Prove the secondary hazard: after closing FDs 0-2, the next open()
+    // reuses FD 0, so any library writing to "stderr" would corrupt that file.
+
+    pid_t pid = fork();
+    ASSERT_NE(pid, -1);
+
+    if( pid == 0 ){
+        close(STDIN_FILENO);
+        close(STDOUT_FILENO);
+        close(STDERR_FILENO);
+
+        // Next open() should get FD 0 (lowest available)
+        int fd = open("/dev/null", O_RDONLY);
+        _exit(fd == 0 ? 0 : 1);
+    }
+
+    int status;
+    waitpid(pid, &status, 0);
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 0) << "Next open() after closing FDs 0-2 should reuse FD 0";
+}
+
+TEST(Daemonize, DevNullRedirectKeepsFDsValid) {
+    // Prove that redirecting to /dev/null (the correct behavior) leaves
+    // FDs 0-2 open and valid.
+
+    pid_t pid = fork();
+    ASSERT_NE(pid, -1);
+
+    if( pid == 0 ){
+        int fd = open("/dev/null", O_RDWR);
+        dup2(fd, STDIN_FILENO);
+        dup2(fd, STDOUT_FILENO);
+        dup2(fd, STDERR_FILENO);
+        if( fd > 2 ) close(fd);
+
+        // FDs 0-2 should all be valid
+        int r0 = fcntl(STDIN_FILENO, F_GETFD);
+        int r1 = fcntl(STDOUT_FILENO, F_GETFD);
+        int r2 = fcntl(STDERR_FILENO, F_GETFD);
+
+        _exit((r0 != -1 && r1 != -1 && r2 != -1) ? 0 : 1);
+    }
+
+    int status;
+    waitpid(pid, &status, 0);
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 0) << "FDs should remain valid after /dev/null redirect";
+}
+
+TEST(Daemonize, DevNullRedirectDoesNotReuseNextFD) {
+    // After correct redirect, next open() should NOT get FD 0/1/2.
+
+    pid_t pid = fork();
+    ASSERT_NE(pid, -1);
+
+    if( pid == 0 ){
+        int fd = open("/dev/null", O_RDWR);
+        dup2(fd, STDIN_FILENO);
+        dup2(fd, STDOUT_FILENO);
+        dup2(fd, STDERR_FILENO);
+        if( fd > 2 ) close(fd);
+
+        int next_fd = open("/dev/null", O_RDONLY);
+        _exit((next_fd > 2) ? 0 : 1);
+    }
+
+    int status;
+    waitpid(pid, &status, 0);
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 0) << "Next open() should get FD > 2 when 0-2 are occupied";
+}
+
+TEST(Daemonize, BackgroundCommandWorksWithDevNull) {
+    // End-to-end: backgrounded command via system() works with /dev/null redirect.
+
+    std::string marker = make_temp_path("devnull");
+    std::remove(marker.c_str());
+
+    pid_t pid = fork();
+    ASSERT_NE(pid, -1);
+
+    if( pid == 0 ){
+        int fd = open("/dev/null", O_RDWR);
+        dup2(fd, STDIN_FILENO);
+        dup2(fd, STDOUT_FILENO);
+        dup2(fd, STDERR_FILENO);
+        if( fd > 2 ) close(fd);
+
+        std::string cmd = "touch " + marker + " &";
+        system(cmd.c_str());
+
+        usleep(200000);
+
+        struct stat st;
+        int exists = (stat(marker.c_str(), &st) == 0) ? 0 : 1;
+        _exit(exists);
+    }
+
+    int status;
+    waitpid(pid, &status, 0);
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 0) << "Background command should work with /dev/null redirect";
+
+    std::remove(marker.c_str());
+}
+
+TEST(Daemonize, BackgroundCommandWithOutputWorksWithDevNull) {
+    // Backgrounded command that writes to stdout/stderr — the scenario from issue #17.
+    // The reporter's script backgrounds a CLI binary that produces output.
+
+    std::string marker = make_temp_path("output");
+    std::remove(marker.c_str());
+
+    pid_t pid = fork();
+    ASSERT_NE(pid, -1);
+
+    if( pid == 0 ){
+        int fd = open("/dev/null", O_RDWR);
+        dup2(fd, STDIN_FILENO);
+        dup2(fd, STDOUT_FILENO);
+        dup2(fd, STDERR_FILENO);
+        if( fd > 2 ) close(fd);
+
+        // Command that writes to both stdout and stderr before creating marker
+        std::string cmd = "sh -c 'echo stdout_test; echo stderr_test >&2; touch " + marker + "' &";
+        system(cmd.c_str());
+
+        usleep(200000);
+
+        struct stat st;
+        int exists = (stat(marker.c_str(), &st) == 0) ? 0 : 1;
+        _exit(exists);
+    }
+
+    int status;
+    waitpid(pid, &status, 0);
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 0) << "Background command with output should work with /dev/null redirect";
+
+    std::remove(marker.c_str());
+}
+
+#endif // _WIN32


### PR DESCRIPTION
## Summary
- **Fixes #17** — backgrounded commands (`command &`) silently fail in legacy mode
- `daemonize()` was `close()`-ing FDs 0-2 instead of redirecting to `/dev/null` via `dup2()`, violating POSIX. Child processes via `system()` inherit closed FDs, causing shells to enter a non-conforming state where backgrounded subprocesses silently fail.
- The fix matches the behavior of `daemon(0, 0)` by opening `/dev/null` with `O_RDWR` and `dup2()`-ing onto FDs 0, 1, 2.

## Changes
- `src/daemonize.cc` — replace `close()` with `/dev/null` redirect
- `tests/test_daemonize.cc` — 6 new regression tests (POSIX-only, skipped on Windows)
- `tests/CMakeLists.txt` — register new test binary
- `.gitignore` — ignore new test binary
- `.github/workflows/*.yml` — CI now triggers on `0.*` release branches

## Test plan
- [x] 77/77 tests pass locally on macOS (including 6 new daemonize tests)
- [ ] Linux CI passes (this is the primary affected platform)
- [ ] macOS CI passes
- [ ] FreeBSD CI passes
- [ ] Windows CI passes (daemonize tests skipped, no regression in other tests)

🔗 Related: will also be applied to the `0.2` branch