### PR TITLE
Add migration guides for v0.1→v0.2 and v0.2→v0.3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,3 +82,12 @@ frequent-cron logs myservice
 frequent-cron stop myservice
 frequent-cron remove myservice
 ```
+
+## Git Workflow
+
+- Never commit directly to main. All work goes on feature branches with PRs.
+- Release branches (`0.1`, `0.2`, `0.3`) hold the latest patch for each minor version.
+- Feature/fix branches are created off the appropriate release branch.
+- PRs target release branches, not main. Main is updated when cutting releases.
+- For fixes spanning multiple release branches, create separate branches and PRs for each.
+- Do not add `Co-Authored-By` trailers to commits.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ frequent-cron remove myservice
 The `install` command also creates platform-native service definitions:
 - **Linux**: systemd unit files
 - **macOS**: launchd plists
+- **FreeBSD**: rc.d scripts
 - **Windows**: Windows Service (SCM) entries
 
 ### Command-Line Options

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -10,7 +10,7 @@ main.cc
   ├── cmd_run()             → Executor + daemonize + run
   └── ServiceRegistry       → install/remove/start/stop/status/list/logs
         ├── Database         → SQLite CRUD
-        ├── PlatformService  → systemd/launchd/SCM
+        ├── PlatformService  → systemd/launchd/rc.d/SCM
         └── LogManager       → per-service log files
 ```
 
@@ -23,7 +23,7 @@ main.cc
 | Process | `process.h` | `process.cc` | Command execution with output capture |
 | Database | `database.h` | `database.cc` | SQLite wrapper, ServiceRecord/ServiceState CRUD |
 | Service Registry | `service_registry.h` | `service_registry.cc` | High-level subcommand handlers |
-| Platform Service | `platform_service.h` | `platform_service.cc` | Abstract interface + systemd/launchd/SCM |
+| Platform Service | `platform_service.h` | `platform_service.cc` | Abstract interface + systemd/launchd/rc.d/SCM |
 | Log Manager | `log_manager.h` | `log_manager.cc` | Per-service log files with rotation |
 | Data Dir | `data_dir.h` | `data_dir.cc` | Platform-specific path resolution |
 | Daemonize | `daemonize.h` | `daemonize.cc` | fork()/setsid() on POSIX, no-op on Windows |
@@ -53,7 +53,7 @@ main() → parse_args() → Config{subcommand=RUN}
 main() → parse_args() → Config{subcommand=INSTALL, service_name="foo"}
   → ServiceRegistry(data_dir)
     → Database::insert_service()     // SQLite insert
-    → PlatformService::install()     // write systemd unit / launchd plist / SCM entry
+    → PlatformService::install()     // write systemd unit / launchd plist / rc.d script / SCM entry
 ```
 
 ### Service Start (`frequent-cron start`)
@@ -98,6 +98,7 @@ class PlatformService {
 Compile-time `#ifdef` selects:
 - `SystemdService` on `__linux__`
 - `LaunchdService` on `__APPLE__`
+- `RcdService` on `__FreeBSD__`
 - `ScmService` on `_WIN32`
 
 ## Build System

--- a/docs/wiki/CLI-Reference.md
+++ b/docs/wiki/CLI-Reference.md
@@ -41,7 +41,7 @@ frequent-cron install <name> --frequency=<ms> --command=<cmd> [options]
 
 Creates:
 - SQLite registry entry
-- systemd unit file (Linux), launchd plist (macOS), or SCM entry (Windows)
+- systemd unit file (Linux), launchd plist (macOS), rc.d script (FreeBSD), or SCM entry (Windows)
 
 ### `remove`
 

--- a/docs/wiki/Configuration.md
+++ b/docs/wiki/Configuration.md
@@ -64,6 +64,6 @@ Affects where the SQLite database, logs, and PID files are stored for service ma
 
 | Variable | Platform | Effect |
 |---|---|---|
-| `XDG_DATA_HOME` | Linux | Overrides default data directory base (default: `~/.local/share`) |
+| `XDG_DATA_HOME` | Linux, FreeBSD | Overrides default data directory base (default: `~/.local/share`) |
 | `HOME` | POSIX | Used to resolve data directory when XDG_DATA_HOME is not set |
 | `LOCALAPPDATA` | Windows | Used for data directory (default: `C:\Users\<user>\AppData\Local`) |

--- a/docs/wiki/Contributing.md
+++ b/docs/wiki/Contributing.md
@@ -54,7 +54,7 @@ make test ARGS="--output-on-failure -R Database"
 
 ## Platform Notes
 
-- Use `#ifdef _WIN32` / `#elif defined(__APPLE__)` / `#else` for platform-specific code
+- Use `#ifdef _WIN32` / `#elif defined(__APPLE__)` / `#elif defined(__FreeBSD__)` / `#else` for platform-specific code
 - Test on all three platforms via CI before submitting a PR
 - Windows requires `WIN32_LEAN_AND_MEAN` before `<windows.h>` and `NOMINMAX` to avoid macro conflicts
 - macOS uses `_NSGetExecutablePath()` for binary path detection; Linux uses `/proc/self/exe`

--- a/docs/wiki/FAQ.md
+++ b/docs/wiki/FAQ.md
@@ -50,7 +50,7 @@ Yes. Commands are executed via the system shell (`/bin/sh -c` on POSIX, `cmd.exe
 ### Where is the database stored?
 
 In the platform data directory:
-- Linux: `~/.local/share/frequent-cron/frequent-cron.db`
+- Linux/FreeBSD: `~/.local/share/frequent-cron/frequent-cron.db`
 - macOS: `~/Library/Application Support/frequent-cron/frequent-cron.db`
 - Windows: `%LOCALAPPDATA%\frequent-cron\frequent-cron.db`
 
@@ -64,7 +64,7 @@ frequent-cron start svc --data-dir=/shared/fc
 
 ### What happens if the process dies unexpectedly?
 
-The `status` command checks whether the tracked PID is actually alive. If the process died, it updates the database to `stopped`. If you installed with a platform service (systemd/launchd), the OS will auto-restart it based on the service configuration.
+The `status` command checks whether the tracked PID is actually alive. If the process died, it updates the database to `stopped`. If you installed with a platform service (systemd/launchd/rc.d), the OS will auto-restart it based on the service configuration.
 
 ## Platform
 

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -55,7 +55,7 @@ frequent-cron logs my-poller
 frequent-cron stop my-poller
 ```
 
-The `install` command also creates a platform-native service definition (systemd unit, launchd plist, or Windows Service) so the OS can supervise and auto-restart your service.
+The `install` command also creates a platform-native service definition (systemd unit, launchd plist, rc.d script, or Windows Service) so the OS can supervise and auto-restart your service.
 
 ## 4. Understand Execution Modes
 
@@ -78,4 +78,4 @@ Use async mode with caution -- if your script never exits or is called too frequ
 - [CLI Reference](CLI-Reference) -- full list of commands and options
 - [Service Management](Service-Management) -- managing multiple services
 - [Logging](Logging) -- log capture and rotation
-- [Platform Guides](Platform-Guides) -- systemd, launchd, Windows Service setup
+- [Platform Guides](Platform-Guides) -- systemd, launchd, rc.d, Windows Service setup

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -17,6 +17,8 @@ A lightweight daemon and service manager for running shell commands at milliseco
 - [Troubleshooting](Troubleshooting)
 - [Contributing](Contributing)
 - [Release Notes](Release-Notes)
+- [Migrating v0.1 to v0.2](Migrating-v0.1-to-v0.2)
+- [Migrating v0.2 to v0.3](Migrating-v0.2-to-v0.3)
 
 ## What is frequent-cron?
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,6 +1,6 @@
 # frequent-cron
 
-A lightweight daemon and service manager for running shell commands at millisecond intervals. Sub-second cron for Linux, macOS, and Windows.
+A lightweight daemon and service manager for running shell commands at millisecond intervals. Sub-second cron for Linux, macOS, FreeBSD, and Windows.
 
 ## Quick Links
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -40,6 +40,21 @@ make test
 sudo make install
 ```
 
+## FreeBSD
+
+```bash
+pkg install cmake boost-all sqlite3
+```
+
+```bash
+git clone https://github.com/homer6/frequent-cron.git
+cd frequent-cron
+cmake .
+make -j$(sysctl -n hw.ncpu)
+make test
+make install
+```
+
 ## Windows (vcpkg + Visual Studio)
 
 Prerequisites:

--- a/docs/wiki/Migrating-v0.1-to-v0.2.md
+++ b/docs/wiki/Migrating-v0.1-to-v0.2.md
@@ -1,0 +1,104 @@
+# Migrating from v0.1.x to v0.2.x
+
+This guide covers upgrading from v0.1.x (the original Linux-only daemon) to v0.2.x (cross-platform, modern C++).
+
+## What's New
+
+- **macOS and Windows support**
+- **Asynchronous execution mode** (`--synchronous=false`)
+- **Modern C++23** and modern Boost ASIO (`io_context`/`steady_timer`)
+- **GTest unit tests** and integration test suite
+- **GitHub Actions CI** on Linux, macOS, and Windows
+- **`make install` and `make test`** support
+
+## Breaking Changes
+
+### Build Requirements
+
+| | v0.1.x | v0.2.x |
+|---|---|---|
+| CMake | 2.8+ | 3.5+ |
+| C++ standard | C++03 | C++23 |
+| Platforms | Linux only | Linux, macOS, Windows |
+
+If your build system pins CMake or compiler versions, update them before upgrading.
+
+### Source Layout
+
+v0.1.x was a single file (`src/frequent.cc`). v0.2.x splits into modules:
+
+```
+include/
+  config.h
+  executor.h
+  daemonize.h
+  pid_file.h
+src/
+  main.cc
+  config.cc
+  executor.cc
+  daemonize.cc
+  pid_file.cc
+```
+
+If you were patching `frequent.cc` directly, you'll need to re-apply changes to the appropriate module.
+
+### Daemonization
+
+v0.1.x used the BSD `daemon(0, 0)` call. v0.2.x uses a manual `fork()`/`setsid()` implementation for portability (macOS deprecated `daemon()`).
+
+**Known issue (fixed in v0.2.1):** The v0.2.0 daemonize implementation closed FDs 0-2 instead of redirecting them to `/dev/null`. This caused commands containing backgrounded subprocesses (`command &`) to silently fail on some platforms. **Upgrade to v0.2.1+ to get the fix.** See [#17](https://github.com/homer6/frequent-cron/issues/17).
+
+## No Behavioral Changes
+
+- The CLI is fully backward-compatible. `frequent-cron --frequency=1000 --command="echo hi" --pid-file=/tmp/fc.pid` works identically.
+- The timer/execution engine behavior is unchanged.
+- The `init_script.tpl` service template is still at the project root.
+
+## Migration Steps
+
+### 1. Update build dependencies
+
+```bash
+# Ubuntu/Debian
+sudo apt-get install cmake build-essential libboost-system-dev libboost-program-options-dev
+
+# macOS
+brew install boost cmake
+```
+
+Ensure your compiler supports C++23 (GCC 13+, Clang 16+, MSVC 2022+).
+
+### 2. Build
+
+```bash
+git clone https://github.com/homer6/frequent-cron.git
+cd frequent-cron
+git checkout 0.2
+cmake .
+make
+sudo make install
+```
+
+### 3. Verify
+
+```bash
+make test
+frequent-cron --frequency=1000 --command="echo hello" --pid-file=/tmp/fc_test.pid
+sleep 2
+kill $(cat /tmp/fc_test.pid)
+```
+
+### 4. Update init scripts (optional)
+
+Your existing `init_script.tpl`-based scripts will continue to work without changes. The CLI interface is identical.
+
+## New Capability: Async Mode
+
+v0.2.x adds `--synchronous=false` for non-blocking execution. In this mode, the timer fires regardless of whether the previous command has finished:
+
+```bash
+frequent-cron --frequency=500 --command="/opt/scripts/fast-poll.sh" --synchronous=false
+```
+
+Use with caution -- overlapping commands can exhaust system resources.

--- a/docs/wiki/Migrating-v0.2-to-v0.3.md
+++ b/docs/wiki/Migrating-v0.2-to-v0.3.md
@@ -1,0 +1,150 @@
+# Migrating from v0.2.x to v0.3.x
+
+This guide covers upgrading from v0.2.x to v0.3.x, which adds a full service manager on top of the existing daemon.
+
+## What's New
+
+- **Service management CLI**: `install`, `remove`, `start`, `stop`, `status`, `list`, `logs`
+- **SQLite service registry** for tracking multiple named services
+- **Platform-native service integration**: systemd (Linux), launchd (macOS), rc.d (FreeBSD), SCM (Windows)
+- **Boot-start and auto-restart** on all platforms
+- **Log capture and rotation** (10MB default, 5 rotated files)
+- **FreeBSD support**
+- **70 unit tests** (up from 25)
+
+## Breaking Changes
+
+### Build Requirements
+
+| | v0.2.x | v0.3.x |
+|---|---|---|
+| CMake | 3.5+ | 3.14+ |
+| New dependency | -- | SQLite3 |
+| Platforms | Linux, macOS, Windows | Linux, macOS, FreeBSD, Windows |
+
+### New Dependency: SQLite3
+
+v0.3.x requires SQLite3 for the service registry:
+
+```bash
+# Ubuntu/Debian
+sudo apt-get install libsqlite3-dev
+
+# macOS
+brew install sqlite
+
+# FreeBSD
+pkg install sqlite3
+
+# Windows (vcpkg)
+vcpkg install sqlite3:x64-windows
+```
+
+### init_script.tpl Moved
+
+The init.d service template moved from the project root to `docs/init_script.tpl`. If your deployment scripts reference the old path, update them.
+
+The `install` subcommand is the recommended replacement for init.d scripts -- it generates platform-native service definitions automatically.
+
+### CI Workflow Split
+
+The single `ci.yml` was replaced with per-platform workflow files:
+
+```
+.github/workflows/
+  linux.yml
+  macos.yml
+  freebsd.yml
+  windows.yml
+```
+
+If you forked and modified `ci.yml`, you'll need to migrate your changes.
+
+## No Behavioral Changes to Legacy Mode
+
+- `frequent-cron --frequency=1000 --command="echo hi" --pid-file=/tmp/fc.pid` works identically.
+- The `run` subcommand is functionally equivalent to legacy mode.
+- The timer/execution engine is unchanged.
+- Async mode (`--synchronous=false`) works as before.
+
+## Migration Steps
+
+### 1. Install SQLite3
+
+See the dependency table above for your platform.
+
+### 2. Build
+
+```bash
+git clone https://github.com/homer6/frequent-cron.git
+cd frequent-cron
+git checkout 0.3
+cmake .
+make
+sudo make install
+```
+
+### 3. Verify
+
+```bash
+make test
+frequent-cron --frequency=1000 --command="echo hello" --pid-file=/tmp/fc_test.pid
+sleep 2
+kill $(cat /tmp/fc_test.pid)
+```
+
+### 4. Migrate from init.d to service manager (recommended)
+
+If you're using `init_script.tpl` to manage services, consider migrating to the built-in service manager. It handles PID files, log capture, boot-start, and auto-restart automatically.
+
+**Before (init.d):**
+```bash
+# /etc/init.d/frequent_service
+EXEC=/usr/bin/frequent-cron
+PIDFILE=/var/run/frequent_service.pid
+COMMAND=/tmp/myshell.sh
+FREQUENCY=1000
+
+$EXEC --frequency $FREQUENCY --command $COMMAND --pid-file $PIDFILE
+```
+
+**After (service manager):**
+```bash
+frequent-cron install frequent_service --frequency=1000 --command="/tmp/myshell.sh"
+frequent-cron start frequent_service
+```
+
+This generates a systemd unit file (or launchd plist / rc.d script / SCM entry) automatically. The OS handles boot-start and restart-on-failure.
+
+To see what you get:
+```bash
+frequent-cron status              # all services
+frequent-cron logs frequent_service   # captured output
+```
+
+### 5. Update init_script.tpl path (if keeping init.d)
+
+If you prefer to keep init.d scripts, update any references:
+
+```bash
+# Old path
+init_script.tpl
+
+# New path
+docs/init_script.tpl
+```
+
+Legacy mode is fully supported and will continue to work. The service manager is additive -- you can migrate services one at a time.
+
+## Data Directory
+
+The service manager stores its database, logs, and PID files in a platform-specific directory:
+
+| Platform | User | Root |
+|---|---|---|
+| Linux | `~/.local/share/frequent-cron/` | `/var/lib/frequent-cron/` |
+| macOS | `~/Library/Application Support/frequent-cron/` | -- |
+| FreeBSD | `~/.local/share/frequent-cron/` | `/var/lib/frequent-cron/` |
+| Windows | `%LOCALAPPDATA%\frequent-cron\` | -- |
+
+Override with `--data-dir=<path>` on any command.

--- a/docs/wiki/Platform-Guides.md
+++ b/docs/wiki/Platform-Guides.md
@@ -15,7 +15,7 @@ systemctl status frequent-cron-myservice
 journalctl -u frequent-cron-myservice
 ```
 
-See [docs/ubuntu.md](https://github.com/homer6/frequent-cron/blob/master/docs/ubuntu.md) for full setup instructions.
+See [docs/ubuntu.md](https://github.com/homer6/frequent-cron/blob/main/docs/ubuntu.md) for full setup instructions.
 
 ## macOS (launchd)
 
@@ -31,7 +31,7 @@ You can also manage the service directly with launchctl:
 launchctl list | grep frequent-cron
 ```
 
-See [docs/macos.md](https://github.com/homer6/frequent-cron/blob/master/docs/macos.md) for full setup instructions.
+See [docs/macos.md](https://github.com/homer6/frequent-cron/blob/main/docs/macos.md) for full setup instructions.
 
 ## Windows (Service Control Manager)
 
@@ -46,7 +46,19 @@ sc stop frequent-cron-myservice
 
 Or through the Services MMC snap-in (`services.msc`).
 
-See [docs/windows.md](https://github.com/homer6/frequent-cron/blob/master/docs/windows.md) for full setup instructions.
+See [docs/windows.md](https://github.com/homer6/frequent-cron/blob/main/docs/windows.md) for full setup instructions.
+
+## FreeBSD (rc.d)
+
+When you run `frequent-cron install`, an rc.d script is generated at `/usr/local/etc/rc.d/frequent_cron_<name>` and enabled via `sysrc`.
+
+The script uses the standard `rc.subr` framework:
+```bash
+service frequent_cron_myservice status
+service frequent_cron_myservice restart
+```
+
+See [docs/freebsd.md](https://github.com/homer6/frequent-cron/blob/main/docs/freebsd.md) for full setup instructions.
 
 ## Platform Detection
 
@@ -56,4 +68,5 @@ frequent-cron automatically detects the platform at compile time and selects the
 |---|---|---|
 | Linux | `__linux__` | SystemdService |
 | macOS | `__APPLE__` | LaunchdService |
+| FreeBSD | `__FreeBSD__` | RcdService |
 | Windows | `_WIN32` | ScmService |

--- a/docs/wiki/Service-Management.md
+++ b/docs/wiki/Service-Management.md
@@ -17,7 +17,7 @@ frequent-cron install db-checker --frequency=5000 --command="/opt/scripts/check-
 
 This does two things:
 1. Creates a record in the SQLite database
-2. Generates a platform-native service definition (systemd unit, launchd plist, or Windows Service)
+2. Generates a platform-native service definition (systemd unit, launchd plist, rc.d script, or Windows Service)
 
 ### Start and Stop
 
@@ -65,6 +65,8 @@ Services are tracked in a SQLite database stored in the platform data directory:
 | Linux (user) | `~/.local/share/frequent-cron/` |
 | Linux (root) | `/var/lib/frequent-cron/` |
 | macOS | `~/Library/Application Support/frequent-cron/` |
+| FreeBSD (user) | `~/.local/share/frequent-cron/` |
+| FreeBSD (root) | `/var/lib/frequent-cron/` |
 | Windows | `%LOCALAPPDATA%\frequent-cron\` |
 
 Override with `--data-dir`:


### PR DESCRIPTION
## Summary
- Add `docs/wiki/Migrating-v0.1-to-v0.2.md` — build requirements, source layout, daemonize FD bug, async mode
- Add `docs/wiki/Migrating-v0.2-to-v0.3.md` — SQLite3 dependency, init.d→service manager migration, data directories
- Link both from `docs/wiki/Home.md`

Related: #17, #18, #19