### PR TITLE
Add v0.2.1 and v0.3.1 release notes, document release process

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,3 +91,15 @@ frequent-cron remove myservice
 - PRs target release branches, not main. Main is updated when cutting releases.
 - For fixes spanning multiple release branches, create separate branches and PRs for each.
 - Do not add `Co-Authored-By` trailers to commits.
+
+## Release Process
+
+1. Merge feature/fix PRs into the target release branch (e.g. `0.3`).
+2. Create an annotated tag on the release branch: `git tag v0.3.1 origin/0.3`.
+3. Push the tag: `git push origin v0.3.1`.
+4. Write release notes in `docs/releases/v0.3.1.md` and update `docs/wiki/Release-Notes.md`.
+5. Commit release notes on a feature branch, PR into the release branch, merge.
+6. Merge the latest release branch into main: `git checkout main && git merge 0.3`.
+7. Push main.
+
+Tags are cut from release branches, not main. Main always reflects the latest stable release.

--- a/docs/releases/v0.2.1.md
+++ b/docs/releases/v0.2.1.md
@@ -1,0 +1,18 @@
+# v0.2.1 - Background Command Fix
+
+**Released:** April 8, 2026
+
+Patch release fixing a regression where commands containing backgrounded subprocesses (`command &`) silently failed in legacy mode.
+
+## Bug Fix
+
+- **Fix background commands silently failing in legacy mode ([#17](https://github.com/homer6/frequent-cron/issues/17))** -- `daemonize()` was closing file descriptors 0-2 instead of redirecting them to `/dev/null`. This violates POSIX: child processes launched via `system()` inherit the closed FDs, and shells enter a non-conforming state where backgrounded subprocesses silently fail to execute. The fix uses `open("/dev/null", O_RDWR)` + `dup2()` to match the behavior of `daemon(0, 0)`.
+
+## Testing
+
+- 6 new regression tests for daemonize FD behavior (`tests/test_daemonize.cc`)
+- CI now triggers on release branches (`0.*`) in addition to master
+
+## Upgrading
+
+Drop-in replacement for v0.2.0. No configuration or CLI changes.

--- a/docs/releases/v0.3.1.md
+++ b/docs/releases/v0.3.1.md
@@ -1,0 +1,25 @@
+# v0.3.1 - Background Command Fix + Migration Guides
+
+**Released:** April 8, 2026
+
+Patch release fixing a regression where commands containing backgrounded subprocesses (`command &`) silently failed in legacy mode. Also adds migration guides and documents the release branch workflow.
+
+## Bug Fix
+
+- **Fix background commands silently failing in legacy mode ([#17](https://github.com/homer6/frequent-cron/issues/17))** -- `daemonize()` was closing file descriptors 0-2 instead of redirecting them to `/dev/null`. This violates POSIX: child processes launched via `system()` inherit the closed FDs, and shells enter a non-conforming state where backgrounded subprocesses silently fail to execute. The fix uses `open("/dev/null", O_RDWR)` + `dup2()` to match the behavior of `daemon(0, 0)`.
+
+## Documentation
+
+- Migration guide: [v0.1 to v0.2](../../docs/wiki/Migrating-v0.1-to-v0.2.md)
+- Migration guide: [v0.2 to v0.3](../../docs/wiki/Migrating-v0.2-to-v0.3.md)
+- Git workflow conventions added to CLAUDE.md
+
+## Testing
+
+- 6 new regression tests for daemonize FD behavior (`tests/test_daemonize.cc`)
+- `.gitignore` uses wildcard pattern for test binaries
+- CI now triggers on release branches (`0.*`) in addition to main
+
+## Upgrading
+
+Drop-in replacement for v0.3.0. No configuration or CLI changes.

--- a/docs/wiki/Release-Notes.md
+++ b/docs/wiki/Release-Notes.md
@@ -1,8 +1,16 @@
 # Release Notes
 
+## [v0.3.1](../releases/v0.3.1.md) - Background Command Fix + Migration Guides (April 2026)
+
+Fix backgrounded commands (`&`) silently failing in legacy mode. Add migration guides for v0.1→v0.2 and v0.2→v0.3.
+
 ## [v0.3.0](../releases/v0.3.0.md) - Service Manager (April 2026)
 
 Transforms frequent-cron into a service manager. Register, start, stop, and monitor multiple named services with SQLite, platform-native service integration, and log rotation.
+
+## [v0.2.1](../releases/v0.2.1.md) - Background Command Fix (April 2026)
+
+Fix backgrounded commands (`&`) silently failing in legacy mode.
 
 ## [v0.2.0](../releases/v0.2.0.md) - Modernize and Expand Platform Support (April 2026)
 


### PR DESCRIPTION
## Summary
- Add `docs/releases/v0.2.1.md` and `docs/releases/v0.3.1.md`
- Update `docs/wiki/Release-Notes.md` index with both patch releases
- Add release process section to `CLAUDE.md`