### PR TITLE
Service Logs fix

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -29,6 +29,7 @@ static po::options_description make_run_options(){
         ( "jitter", po::value<int>(), "Maximum timing variance in milliseconds. The actual interval is frequency +/- jitter." )
         ( "jitter-distribution", po::value<std::string>(), "Distribution for jitter: 'uniform' or 'normal'. Defaults to 'uniform'." )
         ( "fire-probability", po::value<double>(), "Probability of firing on each tick (0.0-1.0). Defaults to 1.0." )
+        ( "service-name", po::value<std::string>(), "Service name for log capture (set automatically by 'start')." )
     ;
     return desc;
 }
@@ -115,6 +116,10 @@ static ParseOutput parse_run_args( int argc, char** argv, Subcommand subcmd ){
         if( vm.count("pid-file") ){
             output.config.pid_filename = vm["pid-file"].as<std::string>();
             output.config.has_pid_file = true;
+        }
+
+        if( vm.count("service-name") ){
+            output.config.service_name = vm["service-name"].as<std::string>();
         }
 
         parse_common_options( vm, output.config );

--- a/src/main.cc
+++ b/src/main.cc
@@ -3,10 +3,12 @@
 #include "daemonize.h"
 #include "pid_file.h"
 #include "data_dir.h"
+#include "log_manager.h"
 #include "service_registry.h"
 
 #include <iostream>
 #include <filesystem>
+#include <memory>
 
 static int cmd_run( const Config& config ){
 
@@ -34,8 +36,32 @@ static int cmd_run( const Config& config ){
         }
     }
 
+    // Set up log capture when running as a managed service
+    std::shared_ptr<LogManager> log_mgr;
+    if( !config.service_name.empty() ){
+        auto dir = config.data_dir.empty()
+            ? data_dir::get_default()
+            : std::filesystem::path(config.data_dir);
+        data_dir::ensure_exists(dir);
+        auto log_dir = dir / "logs";
+        std::filesystem::create_directories(log_dir);
+        log_mgr = std::make_shared<LogManager>(
+            log_dir,
+            static_cast<size_t>(config.log_max_size_mb) * 1024 * 1024,
+            config.log_max_files
+        );
+    }
+
     Executor executor( config.command, config.frequency, config.synchronous,
                        config.jitter_ms, config.jitter_distribution, config.fire_probability );
+
+    if( log_mgr ){
+        auto name = config.service_name;
+        executor.set_output_callback( [log_mgr, name]( const std::string& output ){
+            log_mgr->write( name, output );
+        });
+    }
+
     executor.run();
     return 0;
 }

--- a/src/service_registry.cc
+++ b/src/service_registry.cc
@@ -203,7 +203,9 @@ int ServiceRegistry::cmd_start( const std::string& name ){
         << " run"
         << " --frequency=" << service->frequency_ms
         << " --command=\"" << service->command << "\""
-        << " --pid-file=\"" << pid_path.string() << "\"";
+        << " --pid-file=\"" << pid_path.string() << "\""
+        << " --service-name=" << name
+        << " --data-dir=\"" << data_dir_.string() << "\"";
 
     if( !service->synchronous ){
         cmd << " --synchronous=false";


### PR DESCRIPTION
  Issue: homer6/frequent-cron#31

  Fix (3 files):
  - src/config.cc — Added --service-name option to the run subcommand parser
  - src/main.cc — When service_name is set, creates a LogManager and wires it as the executor's OutputCallback, so command output is captured via run_process() instead of being lost through system()
  - src/service_registry.cc — cmd_start now passes --service-name and --data-dir when launching frequent-cron run

  All 95 tests pass, and manual verification confirms frequent-cron logs myticker now shows timestamped output.