### PR TITLE
Add v0.3.2 release notes

### DIFF
--- a/docs/releases/v0.3.2.md
+++ b/docs/releases/v0.3.2.md
@@ -4,9 +4,10 @@
 
 Patch release fixing a critical 100% CPU bug in daemon mode and adding optional jitter and probabilistic firing controls.
 
-## Bug Fix
+## Bug Fixes
 
 - **Fix 100% CPU in daemon mode on macOS ([#32](https://github.com/homer6/frequent-cron/pull/32))** -- The `Executor` (which creates a `boost::asio::io_context` backed by kqueue on macOS) was constructed before `daemonize()` calls `fork()`. kqueue file descriptors are not inherited across fork, so the child process ended up with a stale kqueue fd, causing `kevent()` to return `EBADF` on every call -- turning the ASIO event loop into a busy spin instead of sleeping between timer ticks. Fix: moved `Executor` construction to after `daemonize()`. Affected all daemon-mode executions (both legacy `--frequency=` and `run` subcommand).
+- **Fix service logs showing no output ([#33](https://github.com/homer6/frequent-cron/pull/33), [#31](https://github.com/homer6/frequent-cron/issues/31))** -- `frequent-cron logs <name>` returned empty output for running services. The `run` subcommand was using `system()` which discards stdout/stderr. Fix: added `--service-name` to the `run` parser, wired a `LogManager` as the executor's `OutputCallback` so command output is captured via `run_process()`, and `start` now passes `--service-name` and `--data-dir` when launching the daemon.
 
 ## New Features
 
@@ -14,6 +15,10 @@ Patch release fixing a critical 100% CPU bug in daemon mode and adding optional 
 - **Probabilistic firing ([#30](https://github.com/homer6/frequent-cron/pull/30))** -- `--fire-probability=<0.0-1.0>` skips a percentage of ticks at random. Default is `1.0` (fire every tick), preserving existing behavior.
 - Both features are optional, off by default, and persisted in the SQLite database with automatic schema migration for existing installs.
 - All four platform service definitions (systemd, launchd, rc.d, SCM) pass the new flags through.
+
+## Developer Experience
+
+- **Claude Code skill for frequent-cron ([#34](https://github.com/homer6/frequent-cron/pull/34))** -- Added a Claude Code skill (`.claude/skills/frequent-cron/`) with command reference and service management instructions, enabling AI-assisted operation of the daemon.
 
 ## Testing
 

--- a/docs/wiki/Release-Notes.md
+++ b/docs/wiki/Release-Notes.md
@@ -2,7 +2,7 @@
 
 ## [v0.3.2](../releases/v0.3.2.md) - High CPU Fix + Jitter & Probabilistic Firing (April 2026)
 
-Fix 100% CPU in daemon mode (kqueue fd not inherited across fork). Add `--jitter` and `--fire-probability` flags for timing variance and probabilistic tick skipping.
+Fix 100% CPU in daemon mode (kqueue fd not inherited across fork). Fix service logs showing no output. Add `--jitter` and `--fire-probability` flags for timing variance and probabilistic tick skipping. Add Claude Code skill for AI-assisted operation.
 
 ## [v0.3.1](../releases/v0.3.1.md) - Background Command Fix + Migration Guides (April 2026)
 


### PR DESCRIPTION
## Summary

- Add release notes for v0.3.2 covering all four merged PRs:
  - **#32** -- Fix 100% CPU in daemon mode (kqueue fd stale after fork)
  - **#33** -- Fix service logs showing no output (wired LogManager as OutputCallback)
  - **#30** -- Add `--jitter` and `--fire-probability` flags
  - **#34** -- Add Claude Code skill for AI-assisted operation
- Update `docs/wiki/Release-Notes.md` index

## Test plan

- [ ] Verify release notes render correctly on GitHub
- [ ] Verify wiki index links resolve